### PR TITLE
Added an if statement to data/permissions mkdir

### DIFF
--- a/permissions/permissions.py
+++ b/permissions/permissions.py
@@ -297,7 +297,8 @@ class Permissions:
             ret = dataIO.load_json("data/permissions/perms.json")
         except:
             ret = {}
-            os.mkdir("data/permissions")
+            if not os.path.exists("data/permissions"):
+                os.mkdir("data/permissions")
             dataIO.save_json("data/permissions/perms.json", ret)
         return ret
 


### PR DESCRIPTION
In the rare case that someone deletes all of their perms.json. This traceback occurs when reloading the cog to hopefully make a new json.

[07/09/2016 15:29] ERROR red on_command_error 88: Exception in command 'reload'
Traceback (most recent call last):
  File "C:\Users\USER\Desktop\Ramses\cogs\permissions.py", line 297, in _load_perms
    ret = dataIO.load_json("data/permissions/perms.json")
  File "C:\Users\USER\Desktop\Ramses\cogs\utils\dataIO.py", line 25, in load_json
    return self._read_json(filename)
  File "C:\Users\USER\Desktop\Ramses\cogs\utils\dataIO.py", line 48, in _read_json
    with open(filename, encoding='utf-8', mode="r") as f:
FileNotFoundError: [Errno 2] No such file or directory: 'data/permissions/perms.json'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\USER\AppData\Local\Programs\Python\Python35\lib\site-packages\discord\ext\commands\core.py", line 50, in wrapped
    ret = yield from coro(*args, **kwargs)
  File "C:\Users\USER\Desktop\Ramses\cogs\owner.py", line 150, in _reload
    self._load_cog(module)
  File "C:\Users\USER\Desktop\Ramses\cogs\owner.py", line 551, in _load_cog
    self.bot.load_extension(mod_obj.__name__)
  File "C:\Users\USER\AppData\Local\Programs\Python\Python35\lib\site-packages\discord\ext\commands\bot.py", line 719, in load_extension
    lib.setup(self)
  File "C:\Users\USER\Desktop\Ramses\cogs\permissions.py", line 874, in setup
    n = Permissions(bot)
  File "C:\Users\USER\Desktop\Ramses\cogs\permissions.py", line 102, in __init__
    self.perms_we_want = self._load_perms()
  File "C:\Users\USER\Desktop\Ramses\cogs\permissions.py", line 300, in _load_perms
    os.mkdir("data/permissions")
FileExistsError: [WinError 183] Cannot create a file when that file already exists: 'data/permissions'