### PR TITLE
[Admin] fix issue with announcer

### DIFF
--- a/admin/admin.py
+++ b/admin/admin.py
@@ -355,13 +355,23 @@ class Admin:
                 continue
             chan = server.default_channel
             if chan is None:
-                log.debug(
-                    "No default channel for {}, skipping".format(
-                        server.name
-                    )
-                )
-                await asyncio.sleep(1)
-                continue  # Skip to next because there's no default channel
+                chan_list = [
+                    c for c in sorted(
+                        server.channels, key=lambda ch: ch.position
+                    ) if c.type.name == "text"
+                ]
+                for ch in chan_list:
+                    roleless_member = [
+                        m for m in server.members if m.roles == [
+                            server.default_role
+                        ]
+                    ][0]
+                    if ch.permissions_for(roleless_member).read_messages and\
+                            ch.permissions_for(server.me).send_messages:
+                        chan = ch
+                        break
+                else:
+                    continue  # No valid channel found, so move on
             log.debug("Looking to announce to {} on {}".format(chan.name,
                                                                server.name))
             me = server.me

--- a/admin/admin.py
+++ b/admin/admin.py
@@ -354,6 +354,14 @@ class Admin:
             if server == self._announce_server:
                 continue
             chan = server.default_channel
+            if chan is None:
+                log.debug(
+                    "No default channel for {}, skipping".format(
+                        server.name
+                    )
+                )
+                await asyncio.sleep(1)
+                continue  # Skip to next because there's no default channel
             log.debug("Looking to announce to {} on {}".format(chan.name,
                                                                server.name))
             me = server.me


### PR DESCRIPTION
Makes it so if the server has no default channel, we skip to the next server. Should prevent announcer from hanging up and never actually announcing to any server. Obviously not ideal to just skip those servers but is probably better than leaving it as is