### PR TITLE
Add hidehelp toggle

### DIFF
--- a/permissions/permissions.py
+++ b/permissions/permissions.py
@@ -20,6 +20,97 @@ from __main__ import send_cmd_help, settings
 log = logging.getLogger("red.permissions")
 
 
+class CustomHelpFormatter(commands.HelpFormatter):
+    """Derived from discord.ext.commands.HelpFormatter
+    Makes base class permissions-aware.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def format(self):
+        """Overrides HelpFormatter.format()
+        Does not display help for command if user does not have permission.
+        """
+
+        # Return super() if there is nothing to be done
+        perm_cog = self.context.bot.get_cog('Permissions')
+        if (not perm_cog or not hasattr(perm_cog, 'resolve_permission') or
+                self.context.message.channel.is_private or
+                self.context.message.author.id == settings.owner):
+            return super().format()
+
+        # self._paginator is defined outside init in base class
+        # noinspection PyAttributeOutsideInit
+        self._paginator = commands.Paginator()
+
+        # Check if help is being called for a command
+        if isinstance(self.command, commands.Command):
+            # Make a shallow copy and change the command
+            fake_context = copy.copy(self.context)
+            fake_context.command = self.command
+            has_perm = perm_cog.resolve_permission(fake_context)
+            if not has_perm:
+                self._paginator.add_line("Command disabled.", empty=True)
+                self._paginator.close_page()
+                return self._paginator.pages
+            else:
+                return super().format()
+
+        # Help is being called for a cog, group, or bot
+        # If subcommand list is empty, do not return normal help text
+        if len(list(self.filter_command_list())) == 0:
+            self._paginator.add_line("Command disabled.", empty=True)
+            self._paginator.close_page()
+            return self._paginator.pages
+
+        return super().format()
+
+    def filter_command_list(self):
+        """Overrides HelpFormatter.format()
+        Does not display help for command if user does not have permission.
+        """
+
+        perm_cog = self.context.bot.get_cog('Permissions')
+        if (not perm_cog or not hasattr(perm_cog, 'resolve_permission') or
+                self.context.message.channel.is_private or
+                self.context.message.author.id == settings.owner):
+            return super().filter_command_list()
+
+        # noinspection PyShadowingBuiltins
+        def predicate(tuple):
+            cmd = tuple[1]
+            if self.is_cog():
+                # filter commands that don't exist to this cog.
+                if cmd.instance is not self.command:
+                    return False
+
+            if cmd.hidden and not self.show_hidden:
+                return False
+
+            # Make a shallow copy and change the command.
+            fake_context = copy.copy(self.context)
+            fake_context.command = cmd
+            has_perm = perm_cog.resolve_permission(fake_context)
+            if not has_perm:
+                return False
+
+            if self.show_check_failure:
+                # we don't wanna bother doing the checks if the user does not
+                # care about them, so just return true.
+                return True
+
+            try:
+                return (cmd.can_run(self.context) and
+                        self.context.bot.can_run(self.context))
+            except commands.CommandError:
+                return False
+
+        iterator = (self.command.commands.items() if not self.is_cog()
+                    else self.context.bot.commands.items())
+        return filter(predicate, iterator)
+
+
 class PermissionsError(CommandNotFound):
     """
     Base exception for all others in this module
@@ -97,6 +188,9 @@ class Permissions:
 
     def __init__(self, bot):
         self.bot = bot
+
+        # Set formatter to our permissions-aware formatter
+        self.bot.formatter = CustomHelpFormatter()
 
         # All the saved permission levels with role ID's
         self.perms_we_want = self._load_perms()
@@ -854,6 +948,35 @@ class Permissions:
 
         await self._lock_server(command, server, False)
         await self.bot.say("Server unlocked {}".format(command))
+
+    @p.group(pass_context=True)
+    async def hidehelp(self, ctx):
+        """Toggle help filtering based on permissions"""
+        if ctx.invoked_subcommand is None or \
+                isinstance(ctx.invoked_subcommand, commands.Group):
+            await send_cmd_help(ctx)
+
+    @hidehelp.command("on")
+    async def turn_on(self):
+        """Turn help filtering on"""
+        if self._is_on():
+            await self.bot.say("Help filtering already on")
+        else:
+            self.bot.formatter = CustomHelpFormatter()
+            await self.bot.say("Help filtering turned on")
+
+    @hidehelp.command(name="off")
+    async def turn_off(self):
+        """Turn help filtering off"""
+        if self._is_on():
+            self.bot.formatter = commands.HelpFormatter()
+            await self.bot.say("Help filtering turned off")
+        else:
+            await self.bot.say("Help filtering already off")
+
+    def _is_on(self):
+        """Check if filtering is enabled"""
+        return isinstance(self.bot.formatter, CustomHelpFormatter)
 
     async def command_error(self, error, ctx):
         cmd = ctx.command


### PR DESCRIPTION
This adds an option to hide help for commands that a user does not have permissions for. This affects `[p]help` and `[p]help command` when typed in a channel, but has no effect on help commands sent via DMs. The toggle commands are `[p]p hidehelp on` and `[p]p hidehelp off`. 

I have a working version as a separate cog here: 
(the command names are different, but the functionality is the same)
https://github.com/ritsu/RitsuCogs/tree/master/helpless

The way it works is it sets `bot.formatter` to a derived class that inherits from `commands.HelpFormatter` and overrides the `HelpFormatter.format()` and `HelpFormatter.filter_command_list()` methods. The toggle command just switches bot.formatter between `commands.HelpFormatter` and the derived class.

It was suggested that I PR this here. I'm happy with either merging it or keeping it as a separate cog, though I think merging makes more sense. 