### PR TITLE
Prevent [p]p role deny from mentioning @everyone

### DIFF
--- a/permissions/permissions.py
+++ b/permissions/permissions.py
@@ -777,12 +777,12 @@ class Permissions:
                 raise e
         role = self._get_role(server.roles, role)
         await self._set_permission(command_obj, server, role=role, allow=False)
-        
+
         if role.name.startswith('@'):
             _rolename = role.name[1:]
         else:
             _rolename = role.name
-            
+
         await self.bot.say("Role {} denied use of {}.".format(_rolename,
                                                               command))
 

--- a/permissions/permissions.py
+++ b/permissions/permissions.py
@@ -777,8 +777,13 @@ class Permissions:
                 raise e
         role = self._get_role(server.roles, role)
         await self._set_permission(command_obj, server, role=role, allow=False)
-
-        await self.bot.say("Role {} denied use of {}.".format(role.name,
+        
+        if role.name.startswith('@'):
+            _rolename = role.name[1:]
+        else:
+            _rolename = role.name
+            
+        await self.bot.say("Role {} denied use of {}.".format(_rolename,
                                                               command))
 
     @role.command(pass_context=True, name="reset")


### PR DESCRIPTION
Yeah, that kind of thing made some *accidents* (oh hello @everyone in a 10.000 members server). that commit should fix it