### PR TITLE
[mentiontracker] save settings when unregistering

### DIFF
--- a/mentiontracker/mentiontracker.py
+++ b/mentiontracker/mentiontracker.py
@@ -62,6 +62,7 @@ class MentionTracker:
         s = ctx.message.server
         if user.id in self.mail:
             del self.mail[user.id]
+            fileIO("data/mentiontracker/mail.json", "save", self.mail)
             await self.bot.say("You will stop receiving mention mail.")
         else:
             await self.bot.say("You haven't registered yet, try {}.".format(


### PR DESCRIPTION
A user reported inability to unregister for mentions, and I tracked it down to the data not being saved.